### PR TITLE
Update monitor.ts

### DIFF
--- a/src/streaming/monitor.ts
+++ b/src/streaming/monitor.ts
@@ -1142,6 +1142,14 @@ export function monitorPlaybackHealth(
           return;
         }
 
+        // For noVideo profiles (e.g., staticPage), there is no video element to monitor. Skip all video health checks and just emit a status update.
+        if(profile.noVideo) {
+
+          emitStatusUpdate();
+
+          return;
+        }
+
         // Capture current timestamp for all timing calculations in this check cycle.
         const now = Date.now();
 


### PR DESCRIPTION
staticPage Profile not honoring noVideo, and was resetting repeatedly.

Supporting logs:
```console
[2026/02/19 09:05:27.351] [weatherscan-kn29tt] Streaming Weatherscan (staticPage, FFmpeg). Tuned in 1.3s.
[2026/02/19 09:05:29.361] [WARN] [weatherscan-kn29tt] Video element not found (attempt 1/3). Context: main page, frames: 1, videoCount: 0.
[2026/02/19 09:05:31.355] [WARN] [weatherscan-kn29tt] Video element not found (attempt 2/3). Context: main page, frames: 1, videoCount: 0.
[2026/02/19 09:05:31.355] [WARN] [weatherscan-kn29tt] Re-search did not find video in any frame.
[2026/02/19 09:05:33.358] [WARN] [weatherscan-kn29tt] Video element not found (attempt 3/3). Context: main page, frames: 1, videoCount: 0.
[2026/02/19 09:05:33.358] [WARN] [weatherscan-kn29tt] Video element not found. Attempting page navigation...
[2026/02/19 09:05:44.445] [WARN] [weatherscan-kn29tt] Failed to reinitialize video after page navigation: Waiting for selector `video` failed.
[2026/02/19 09:05:44.446] [WARN] [weatherscan-kn29tt] Page navigation unsuccessful.
[2026/02/19 09:05:45.366] [WARN] [weatherscan-kn29tt] Video element not found (attempt 4/3). Context: main page, frames: 1, videoCount: 0.
[2026/02/19 09:05:45.366] [WARN] [weatherscan-kn29tt] Video element not found. Attempting page navigation...
[2026/02/19 09:05:55.563] [WARN] [weatherscan-kn29tt] Failed to reinitialize video after page navigation: Waiting for selector `video` failed.
[2026/02/19 09:05:55.564] [WARN] [weatherscan-kn29tt] Page navigation unsuccessful.
[2026/02/19 09:05:57.377] [WARN] [weatherscan-kn29tt] Video element not found (attempt 5/3). Context: main page, frames: 1, videoCount: 0.
[2026/02/19 09:05:57.377] [WARN] [weatherscan-kn29tt] Video element not found. Attempting page navigation...
[2026/02/19 09:06:07.575] [WARN] [weatherscan-kn29tt] Failed to reinitialize video after page navigation: Waiting for selector `video` failed.
[2026/02/19 09:06:07.576] [WARN] [weatherscan-kn29tt] Page navigation unsuccessful.
[2026/02/19 09:06:09.388] [WARN] [weatherscan-kn29tt] Video element not found (attempt 6/3). Context: main page, frames: 1, videoCount: 0.
[2026/02/19 09:06:09.388] [WARN] [weatherscan-kn29tt] Video element not found. Attempting page navigation...
[2026/02/19 09:06:09.388] [ERROR] [weatherscan-kn29tt] Exceeded maximum page navigations (3 in 15 minutes). Cannot recover without video element.
```