### PR TITLE
Add DirecTV Stream as predefined multi-channel provider

### DIFF
--- a/src/config/sites.ts
+++ b/src/config/sites.ts
@@ -308,6 +308,20 @@ export const SITE_PROFILES: Record<string, SiteProfile> = {
     summary: "Static pages (no video)"
   },
 
+  // Profile for DirecTV Stream (stream.directv.com) live channel guide. The guide renders channel logos as background-image divs in a scrollable grid. Clicking
+  // a tile opens a mini-guide overlay containing a circular play button identified by aria-label^="on now,". The channelSelector is the channel's resourceId
+  // (UUID) from the DirecTV Stream API, matched against the background-image URL of the channel logo div. Uses selectReadyVideo because the guide page contains
+  // multiple video elements. Note: DirecTV Stream enforces a single concurrent stream per account.
+  directvStream: {
+
+    category: "multiChannel",
+    channelSelection: { matchSelector: "[style*=\"{channel}\"]", playSelector: "[aria-label^=\"on now,\"]", strategy: "tileClick" },
+    description: "DirecTV Stream live channel guide. Set Channel Selector to the channel's resourceId (UUID) to match the channel logo background-image URL.",
+    extends: "fullscreenApi",
+    selectReadyVideo: true,
+    summary: "DirecTV Stream (tile + play button, needs resourceId)"
+  },
+
   // Profile for YouTube TV (tv.youtube.com/live). The guide grid renders all ~256 channel rows in the DOM simultaneously (no virtualization), each containing a
   // direct watch URL. The youtubeGrid strategy performs a single querySelector to find the target channel's watch link via aria-label, extracts the URL, and
   // navigates directly — no scrolling, clicking, or timing workarounds needed. Uses selectReadyVideo because the watch page has ~36 video elements (live preview
@@ -377,6 +391,8 @@ export const DOMAIN_CONFIG: Record<string, DomainConfig> = {
   "fox.com": { loginUrl: "https://www.fox.com", profile: "foxLive", provider: "Fox", providerTag: "foxcom" },
   "foxbusiness.com": { profile: "embeddedDynamicMultiVideo", provider: "Fox Business" },
   "foxnews.com": { profile: "embeddedDynamicMultiVideo", provider: "Fox News" },
+  "directv.com": { profile: "directvStream", provider: "DirecTV Stream", providerTag: "directvstream" },
+  "stream.directv.com": { profile: "directvStream", provider: "DirecTV Stream", providerTag: "directvstream" },
   "foxsports.com": { profile: "fullscreenApi", provider: "Fox Sports" },
   "france24.com": { profile: "embeddedVolumeLock", provider: "France 24" },
   "fyi.tv": { profile: "fullscreenApi", provider: "FYI" },


### PR DESCRIPTION
# Feature Request: Add DirecTV Stream as a Predefined Multi-Channel Provider

## Summary

DirecTV Stream (`stream.directv.com`) works with PrismCast using the existing `multiChannel` profile system. Requesting it be added as a predefined provider so users don't need to manually configure a custom profile and channel selector for each channel.

---

## How It Works

DirecTV Stream's guide is a single-page app. To tune a channel, two clicks are required:

1. Click the channel's tile in the guide grid (identified by its logo `background-image` URL containing the channel's `resourceId` UUID)
2. Click the circular play button in the mini-guide overlay that appears

---

## Required Changes to `sites.js`

### Profile definition

```javascript
directvStream: {
    category: "multiChannel",
    channelSelection: {
        matchSelector: "[style*=\"{channel}\"]",
        playSelector: "[aria-label^=\"on now,\"]",
        strategy: "tileClick"
    },
    description: "DirecTV Stream live channel guide. Channel Selector must be the channel's resourceId (UUID), which appears in the channel logo background-image URL.",
    extends: "fullscreenApi",
    selectReadyVideo: true,
    summary: "DirecTV Stream (tile + play button)"
}
```

### Domain mapping

```javascript
"stream.directv.com": { profile: "directvStream", provider: "DirecTV Stream", providerTag: "directvstream" }
```

---

## Channel Selector Value

Each channel's **Channel Selector** must be set to its `resourceId` — a UUID that appears in the channel logo URL:

```
https://dfwfis.prod.dtvcdn.com/catalog/image/imageserver/v1/service/channel/{resourceId}/chlogo-clb-guide/60/45
```

The `matchSelector` uses `[style*="{channel}"]` which matches any element whose `style` attribute contains that UUID string — which is exactly how the channel tiles render their logos in the DOM:

```html
<div style="background-image: url('https://dfwfis.prod.dtvcdn.com/.../channel/{resourceId}/chlogo-clb-guide/60/45');">
```

---

## All Channels Share the Same URL

Every channel uses `https://stream.directv.com/guide` as its stream URL. The `channelSelector` (resourceId) is what differentiates them.

### Example channel config (JSON import format)

```json
{
  "buzzr": {
    "name": "Buzzr",
    "url": "https://stream.directv.com/guide",
    "profile": "directvStream",
    "channelSelector": "affd33fa-627b-43d7-9123-6d80501cc8d1",
    "channelNumber": 4335
  }
}
```

---

## DOM Details (for verification)

**Channel tile selector** — matches via `background-image` style containing the resourceId UUID:
```
[style*="{resourceId}"]
```

**Play button selector** — circular play button in the mini-guide overlay:
```
[aria-label^="on now,"]
```
Full aria-label format: `"on now, {Show Name}, press enter to play"`

The `^=` (starts-with) operator is required — the label varies by current show title.

---

## Single Stream Limitation

DirecTV Stream only allows one concurrent stream per account. This is a provider limitation, not a PrismCast issue. The existing `DELETE /streams/:id` endpoint handles this gracefully — the previous stream times out naturally after the idle timeout expires, or can be terminated before switching channels.

---

## Testing

Verified working on 200+ channels across a full DirecTV Stream subscription. The `tileClick` strategy correctly handles the two-step tile → play button interaction and the `selectReadyVideo: true` flag is required as the guide page contains multiple video elements.