### PR TITLE
Fix native HLS relay dropping EXT-X-MAP for fMP4/CMAF sources

### DIFF
--- a/src/native/proxy.ts
+++ b/src/native/proxy.ts
@@ -284,6 +284,7 @@ interface VideoTrackingState {
   lastStoredMapUri: Nullable<string>;
   lastSegmentTime: number;
   lastTargetDuration: number;
+  mapVersion: number;
   metadata: SegmentMetadata;
   segmentIndex: number;
   segmentTracker: SegmentFetchTracker;
@@ -302,6 +303,7 @@ interface AudioTrackingState {
   highWaterSequence: number;
   lastTargetDuration: number;
   lastStoredMapUri: Nullable<string>;
+  mapVersion: number;
   metadata: SegmentMetadata;
   segmentIndex: number;
   segmentTracker: SegmentFetchTracker;
@@ -888,6 +890,7 @@ async function processAudioStream(ctx: ProxyContext, audio: AudioTrackingState, 
 
         storeAudioInitSegment(ctx.streamId, initData);
         audio.lastStoredMapUri = seg.mapUri;
+        audio.mapVersion++;
       }
     }
 
@@ -904,7 +907,7 @@ async function processAudioStream(ctx: ProxyContext, audio: AudioTrackingState, 
     storeAudioSegment(ctx.streamId, filename, segmentData);
     audio.fetchedSequences.add(seg.sequence);
     audio.highWaterSequence = Math.max(audio.highWaterSequence, seg.sequence);
-    storeSegmentMetadata(audio.metadata, filename, seg, "audio-init.mp4");
+    storeSegmentMetadata(audio.metadata, filename, seg, "audio-init.mp4?v=" + String(audio.mapVersion));
     storedAny = true;
 
     audio.segmentIndex++;
@@ -1057,6 +1060,7 @@ export function createNativeProxy(options: NativeProxyOptions): NativeProxy {
     lastSegmentTime: 0,
     lastStoredMapUri: null,
     lastTargetDuration: 6,
+    mapVersion: 0,
     metadata: createSegmentMetadata(),
     segmentIndex: prerollSegmentCount,
     segmentTracker: { consecutiveFailures: 0, debugLabel: "Segment", label: "segment" },
@@ -1072,6 +1076,7 @@ export function createNativeProxy(options: NativeProxyOptions): NativeProxy {
     highWaterSequence: -1,
     lastStoredMapUri: null,
     lastTargetDuration: 6,
+    mapVersion: 0,
     metadata: createSegmentMetadata(),
     segmentIndex: 0,
     segmentTracker: { consecutiveFailures: 0, debugLabel: "Audio segment", label: "audio segment" },
@@ -1349,6 +1354,7 @@ export function createNativeProxy(options: NativeProxyOptions): NativeProxy {
 
           storeInitSegment(streamId, initData);
           video.lastStoredMapUri = seg.mapUri;
+          video.mapVersion++;
         }
       }
 
@@ -1369,7 +1375,7 @@ export function createNativeProxy(options: NativeProxyOptions): NativeProxy {
       storeSegment(streamId, filename, segmentData);
       video.fetchedSequences.add(seg.sequence);
       video.highWaterSequence = Math.max(video.highWaterSequence, seg.sequence);
-      storeSegmentMetadata(video.metadata, filename, seg, "init.mp4");
+      storeSegmentMetadata(video.metadata, filename, seg, "init.mp4?v=" + String(video.mapVersion));
       storedAny = true;
 
       video.lastSegmentSize = segmentData.length;

--- a/src/native/proxy.ts
+++ b/src/native/proxy.ts
@@ -573,8 +573,30 @@ function buildVariantPlaylist(segmentEntries: string[], metadata: SegmentMetadat
   const discSeq = metadata.totalDiscontinuities - windowDiscontinuities;
   const discontinuitySequence = (discSeq > 0) ? discSeq : undefined;
 
-  const entries = segmentEntries.map((filename) => buildEntryFromMetadata(filename, metadata, targetDuration));
+  const entries: PlaylistSegmentEntry[] = [];
+  let previousMapUri: string | undefined = firstEntry ? metadata.mapUris.get(firstEntry) : undefined;
 
+  for(const filename of segmentEntries) {
+
+    const entry = buildEntryFromMetadata(filename, metadata, targetDuration);
+    const currentMapUri = metadata.mapUris.get(filename);
+
+    // Re-emit EXT-X-MAP inline whenever the map URI changes mid-window - this is what tells an
+    // fMP4/CMAF client (Channels DVR's remuxer) to reinitialize its demuxer at a discontinuity
+    // boundary (ad break, codec change). The very first segment is already covered by the
+    // playlist-level initialMapUri below, so skip it here to avoid a redundant duplicate tag.
+    if(currentMapUri && (filename !== firstEntry) && (currentMapUri !== previousMapUri)) {
+
+      entry.mapUri = currentMapUri;
+    }
+
+    if(currentMapUri) {
+
+      previousMapUri = currentMapUri;
+    }
+
+    entries.push(entry);
+  }
   // Determine the initial EXT-X-MAP URI for this playlist window from the first segment's metadata. Required for fMP4 sources so clients know where to fetch the
   // init segment (codec configuration) before requesting any media segment. Absent for MPEG-TS sources, which carry codec info in every segment.
   const initialMapUri = firstEntry ? metadata.mapUris.get(firstEntry) : undefined;

--- a/src/native/proxy.ts
+++ b/src/native/proxy.ts
@@ -5,7 +5,15 @@
 import { LOG, chromeFetch, realClock, startTimer } from "../utils/index.ts";
 import { buildPrerollEntries, computePrerollWindow } from "../streaming/preroll.ts";
 import { decryptSegment, deriveIvFromSequence, fetchDecryptionKey, parseExplicitIv } from "./decrypt.ts";
-import { storeAudioSegment, storeSegment, updateAudioPlaylist, updatePlaylist, updateVideoPlaylist } from "../streaming/hlsSegments.ts";
+import {
+  storeAudioInitSegment,
+  storeAudioSegment,
+  storeInitSegment,
+  storeSegment,
+  updateAudioPlaylist,
+  updatePlaylist,
+  updateVideoPlaylist
+} from "../streaming/hlsSegments.ts";
 import { CONFIG } from "../config/index.ts";
 import type { CaptureCodec } from "../streaming/codec.ts";
 import type { Clock } from "../utils/index.ts";
@@ -185,6 +193,9 @@ interface ParsedSegment {
 
   // Absolute segment URL.
   url: string;
+
+  // Absolute URI from the most recent #EXT-X-MAP preceding this segment, or null if none is in effect.
+  mapUri: Nullable<string>;
 }
 
 /**
@@ -229,6 +240,9 @@ interface SegmentMetadata {
   // Total number of discontinuities observed across all segments ever stored. Used with the count of discontinuities in the current playlist window to compute the
   // #EXT-X-DISCONTINUITY-SEQUENCE header value.
   totalDiscontinuities: number;
+
+  // Absolute #EXT-X-MAP URI in effect for each segment, keyed by local filename.
+  mapUris: Map<string, string>;
 }
 
 // Proxy State Types.
@@ -267,6 +281,7 @@ interface VideoTrackingState {
   highWaterSequence: number;
   lastMediaSequence: number;
   lastSegmentSize: Nullable<number>;
+  lastStoredMapUri: Nullable<string>;
   lastSegmentTime: number;
   lastTargetDuration: number;
   metadata: SegmentMetadata;
@@ -286,6 +301,7 @@ interface AudioTrackingState {
   fetchedSequences: Set<number>;
   highWaterSequence: number;
   lastTargetDuration: number;
+  lastStoredMapUri: Nullable<string>;
   metadata: SegmentMetadata;
   segmentIndex: number;
   segmentTracker: SegmentFetchTracker;
@@ -390,6 +406,7 @@ function parseVariantManifest(body: string, baseUrl: string): ManifestParseResul
   let currentSequence = mediaSequence;
   let currentManifestKeyUrl: Nullable<string> = null;
   let currentIvHex: Nullable<string> = null;
+  let currentMapUri: Nullable<string> = null;
 
   // Pending metadata flags - accumulated from tags between segments and attached to the next #EXTINF.
   let pendingCueIn = false;
@@ -423,6 +440,16 @@ function parseVariantManifest(body: string, baseUrl: string): ManifestParseResul
       }
 
       continue;
+    }
+
+    if(trimmed.startsWith("#EXT-X-MAP:")) {
+
+      const uri = /URI="([^"]+)"/.exec(trimmed)?.[1];
+
+      if(uri) { currentMapUri = resolveUrl(uri, baseUrl); }
+
+      continue;
+
     }
 
     if(trimmed === "#EXT-X-DISCONTINUITY") {
@@ -491,6 +518,7 @@ function parseVariantManifest(body: string, baseUrl: string): ManifestParseResul
       duration,
       ivHex: currentIvHex,
       keyUrl: currentManifestKeyUrl,
+      mapUri: currentMapUri,
       programDateTime: pendingProgramDateTime,
       sequence: currentSequence,
       url: resolveUrl(segUrl, baseUrl)
@@ -547,7 +575,11 @@ function buildVariantPlaylist(segmentEntries: string[], metadata: SegmentMetadat
 
   const entries = segmentEntries.map((filename) => buildEntryFromMetadata(filename, metadata, targetDuration));
 
-  return buildPlaylist({ discontinuitySequence, mediaSequence, targetDuration, version: 3 }, entries);
+  // Determine the initial EXT-X-MAP URI for this playlist window from the first segment's metadata. Required for fMP4 sources so clients know where to fetch the
+  // init segment (codec configuration) before requesting any media segment. Absent for MPEG-TS sources, which carry codec info in every segment.
+  const initialMapUri = firstEntry ? metadata.mapUris.get(firstEntry) : undefined;
+
+  return buildPlaylist({ discontinuitySequence, initialMapUri, mediaSequence, targetDuration, version: initialMapUri ? 7 : 3 }, entries);
 }
 
 /**
@@ -563,6 +595,7 @@ function createSegmentMetadata(): SegmentMetadata {
     cueOuts: new Map<string, string>(),
     discontinuities: new Map<string, boolean>(),
     durations: new Map<string, number>(),
+    mapUris: new Map<string,string>(),
     timestamps: new Map<string, string>(),
     totalDiscontinuities: 0
   };
@@ -576,7 +609,7 @@ function createSegmentMetadata(): SegmentMetadata {
  * @param filename - The local segment filename (e.g., "segment0.ts").
  * @param seg - The parsed segment with upstream metadata.
  */
-function storeSegmentMetadata(meta: SegmentMetadata, filename: string, seg: ParsedSegment): void {
+function storeSegmentMetadata(meta: SegmentMetadata, filename: string, seg: ParsedSegment, mapUriPath?: string): void {
 
   meta.durations.set(filename, seg.duration);
 
@@ -604,6 +637,12 @@ function storeSegmentMetadata(meta: SegmentMetadata, filename: string, seg: Pars
   if(seg.cueOutCont !== null) {
 
     meta.cueOutConts.set(filename, seg.cueOutCont);
+  }
+
+  if(seg.mapUri && mapUriPath) {
+
+
+    meta.mapUris.set(filename, mapUriPath);
   }
 }
 
@@ -677,6 +716,7 @@ function pruneMetadata(meta: SegmentMetadata, activeSegments: Set<string>): void
       meta.discontinuities.delete(key);
       meta.durations.delete(key);
       meta.timestamps.delete(key);
+      meta.mapUris.delete(key);
     }
   }
 }
@@ -817,6 +857,18 @@ async function processAudioStream(ctx: ProxyContext, audio: AudioTrackingState, 
       break;
     }
 
+    if(seg.mapUri && (seg.mapUri !== audio.lastStoredMapUri)) {
+
+      // eslint-disable-next-line no-await-in-loop
+      const initData = await fetchSegment(audio.segmentTracker, seg.mapUri, seg.sequence, null, null);
+
+      if(initData) {
+
+        storeAudioInitSegment(ctx.streamId, initData);
+        audio.lastStoredMapUri = seg.mapUri;
+      }
+    }
+
     // eslint-disable-next-line no-await-in-loop
     const segmentData = await fetchSegment(audio.segmentTracker, seg.url, seg.sequence, seg.ivHex, seg.keyUrl);
 
@@ -830,7 +882,7 @@ async function processAudioStream(ctx: ProxyContext, audio: AudioTrackingState, 
     storeAudioSegment(ctx.streamId, filename, segmentData);
     audio.fetchedSequences.add(seg.sequence);
     audio.highWaterSequence = Math.max(audio.highWaterSequence, seg.sequence);
-    storeSegmentMetadata(audio.metadata, filename, seg);
+    storeSegmentMetadata(audio.metadata, filename, seg, "audio-init.mp4");
     storedAny = true;
 
     audio.segmentIndex++;
@@ -981,6 +1033,7 @@ export function createNativeProxy(options: NativeProxyOptions): NativeProxy {
     lastMediaSequence: -1,
     lastSegmentSize: null,
     lastSegmentTime: 0,
+    lastStoredMapUri: null,
     lastTargetDuration: 6,
     metadata: createSegmentMetadata(),
     segmentIndex: prerollSegmentCount,
@@ -995,6 +1048,7 @@ export function createNativeProxy(options: NativeProxyOptions): NativeProxy {
     consecutiveManifestFailures: 0,
     fetchedSequences: new Set<number>(),
     highWaterSequence: -1,
+    lastStoredMapUri: null,
     lastTargetDuration: 6,
     metadata: createSegmentMetadata(),
     segmentIndex: 0,
@@ -1262,6 +1316,20 @@ export function createNativeProxy(options: NativeProxyOptions): NativeProxy {
         break;
       }
 
+      if(seg.mapUri && (seg.mapUri !== video.lastStoredMapUri)) {
+
+
+        // eslint-disable-next-line no-await-in-loop
+        const initData = await fetchTrackedSegment(video.segmentTracker, seg.mapUri, seg.sequence, null, null);
+
+        if(initData) {
+
+
+          storeInitSegment(streamId, initData);
+          video.lastStoredMapUri = seg.mapUri;
+        }
+      }
+
       // eslint-disable-next-line no-await-in-loop
       const segmentData = await fetchTrackedSegment(video.segmentTracker, seg.url, seg.sequence, seg.ivHex, seg.keyUrl);
 
@@ -1279,7 +1347,7 @@ export function createNativeProxy(options: NativeProxyOptions): NativeProxy {
       storeSegment(streamId, filename, segmentData);
       video.fetchedSequences.add(seg.sequence);
       video.highWaterSequence = Math.max(video.highWaterSequence, seg.sequence);
-      storeSegmentMetadata(video.metadata, filename, seg);
+      storeSegmentMetadata(video.metadata, filename, seg, "init.mp4");
       storedAny = true;
 
       video.lastSegmentSize = segmentData.length;

--- a/src/streaming/hls.ts
+++ b/src/streaming/hls.ts
@@ -13,7 +13,7 @@ import { deleteResumeData, getResumeSegmentIndex, peekResumeData } from "./hlsRe
 import { emitCurrentSystemStatus, isLoginModeActive, unregisterManagedPage } from "../browser/index.ts";
 import { generatePrerollPlaylist, getPrerollCodec, getPrerollSegmentCount, isPrerollReady } from "./preroll.ts";
 import { getAllChannels, getChannelLogo, isPredefinedChannelDisabled } from "../config/userChannels.ts";
-import { getAudioPlaylist, getAudioSegment, getInitSegment, getPlaylist, getSegment, getVideoPlaylist, waitForPlaylist } from "./hlsSegments.ts";
+import { getAudioInitSegment, getAudioPlaylist, getAudioSegment, getInitSegment, getPlaylist, getSegment, getVideoPlaylist, waitForPlaylist } from "./hlsSegments.ts";
 import { getAuthDomainForChannel, getResolvedChannel, getServiceTagForChannel, isChannelAvailableByService, resolveServiceKey } from "../config/services.ts";
 import { getChannelStreamId, isTerminationInitiated, setChannelStreamId, terminateStream } from "./lifecycle.ts";
 import { getEffectiveCaptureCodec, isCaptureHardwareAccelerated } from "./codec.ts";
@@ -355,6 +355,23 @@ export function handleHLSSegment(req: Request, res: Response): void {
 
     updateLastAccess(streamId);
     sendSegment(initSegment, "init.mp4", res);
+
+    return;
+  }
+
+  if(segmentName === "audio-init.mp4") {
+
+    const audioInitSegment = getAudioInitSegment(streamId);
+
+    if(!audioInitSegment) {
+
+      res.status(404).send("Audio init segment not found.");
+
+      return;
+    }
+
+    updateLastAccess(streamId);
+    sendSegment(audioInitSegment, "audio-init.mp4", res);
 
     return;
   }

--- a/src/streaming/hlsSegments.ts
+++ b/src/streaming/hlsSegments.ts
@@ -261,6 +261,43 @@ export function storeInitSegment(streamId: number, data: Buffer): void {
 }
 
 /**
+ * Stores the fMP4 initialization segment for a stream's audio track. Mirrors storeInitSegment() for streams with separate audio renditions, where video and audio
+ * carry independent init segments (separate moov boxes, separate track IDs).
+ * @param streamId - The numeric stream ID.
+ * @param data - The init segment data.
+ */
+export function storeAudioInitSegment(streamId: number, data: Buffer): void {
+
+  const stream = getStream(streamId);
+
+  if(!stream) {
+
+    LOG.debug("streaming:hls", "Attempted to store audio init segment for unknown stream %s.", streamId);
+
+    return;
+  }
+
+  stream.hls.audioInitSegment = data;
+}
+
+/**
+ * Gets the fMP4 initialization segment for a stream's audio track.
+ * @param streamId - The numeric stream ID.
+ * @returns The audio init segment data, or undefined if not found or not yet received.
+ */
+export function getAudioInitSegment(streamId: number): Buffer | undefined {
+
+  const stream = getStream(streamId);
+
+  if(!stream) {
+
+    return undefined;
+  }
+
+  return stream.hls.audioInitSegment ?? undefined;
+}
+
+/**
  * Gets the fMP4 initialization segment for a stream.
  * @param streamId - The numeric stream ID.
  * @returns The init segment data, or undefined if not found or not yet received.

--- a/src/streaming/registry.ts
+++ b/src/streaming/registry.ts
@@ -77,6 +77,10 @@ export interface HLSState {
   // any media segments.
   initSegment: Nullable<Buffer>;
 
+  // The fMP4 initialization segment for the audio track, for streams with separate audio renditions. Mirrors initSegment - sent once, retained for the stream's
+  // lifetime.
+  audioInitSegment: Nullable<Buffer>;
+
   // Map of media segment filenames to their binary data.
   segments: Map<string, Buffer>;
 
@@ -325,6 +329,7 @@ export function createHLSState(): HLSState {
 
   return {
 
+    audioInitSegment: null,
     audioPlaylist: "",
     audioSegmentBytes: 0,
     audioSegments: new Map(),


### PR DESCRIPTION
Fixes #43. Also fixes #44 — same root cause.

The native HLS proxy's manifest parser handled #EXT-X-KEY, #EXT-X-DISCONTINUITY,
#EXT-X-PROGRAM-DATE-TIME, and SCTE-35 cue tags, but never handled #EXT-X-MAP.
For fMP4/CMAF sources (Marquee Sports, PBS Kids), this silently dropped the
init segment reference, so downstream demuxers received media fragments with
no track/codec configuration.

- Marquee (#43): Channels DVR's remuxer couldn't lock a stable TS packet size
  (204/188/192 cycling) since the relayed bytes were fMP4 fragments, not TS.
- PBS Kids (#44): ffmpeg's mov demuxer failed immediately with "could not
  find corresponding trex" / "no tfhd was found" for the same reason.

Changes:
- Parser now tracks #EXT-X-MAP (sticky per RFC 8216 §4.3.2.4) and carries the
  URI through ParsedSegment/SegmentMetadata.
- Init segments are now fetched and stored via the existing
  storeInitSegment/storeAudioInitSegment plumbing, served at init.mp4 /
  audio-init.mp4.
- buildVariantPlaylist now emits EXT-X-MAP and VERSION:7 for fMP4 sources
  (previously hardcoded VERSION:3 unconditionally).

Tested against Marquee Sports (split video/audio renditions) end to end:
confirmed via ffprobe (clean demux, both tracks) and live playback through
Channels DVR.

Known limitation: EXT-X-MAP is not currently re-emitted at a mid-stream
discontinuity boundary if the source's codec parameters change (RFC 8216
§4.3.2.4). Not encountered in testing; flagging as a possible follow-up
rather than blocking this fix.